### PR TITLE
Wikipedia links

### DIFF
--- a/series/ds9.jsonld
+++ b/series/ds9.jsonld
@@ -14,12 +14,17 @@
 	"name": "Star Trek: Deep Space Nine",
 	"identifier": "DS9",
 	"inLanguage": "en",
-	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Episodenliste",
+	"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine",
 	"subjectOf": [
 		{
 			"@type": "Webpage",
+			"inLanguage": "en",
+			"url": "https://en.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine"
+		},
+		{
+			"@type": "Webpage",
 			"inLanguage": "de",
-			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Episodenliste"
+			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine"
 		}
 	],
 	"numberOfSeasons": 7,
@@ -27,7 +32,6 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 1,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_1",
 			"subjectOf": [
 				{
 					"@type": "Webpage",
@@ -421,7 +425,6 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 2,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_2",
 			"subjectOf": [
 				{
 					"@type": "Webpage",
@@ -955,7 +958,6 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 3,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_3",
 			"subjectOf": [
 				{
 					"@type": "Webpage",
@@ -1489,7 +1491,6 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 4,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_4",
 			"subjectOf": [
 				{
 					"@type": "Webpage",
@@ -2003,7 +2004,6 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 5,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_5",
 			"subjectOf": [
 				{
 					"@type": "Webpage",
@@ -2537,7 +2537,6 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 6,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_6",
 			"subjectOf": [
 				{
 					"@type": "Webpage",
@@ -3071,7 +3070,6 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 7,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_7",
 			"subjectOf": [
 				{
 					"@type": "Webpage",

--- a/series/ds9.jsonld
+++ b/series/ds9.jsonld
@@ -15,12 +15,26 @@
 	"identifier": "DS9",
 	"inLanguage": "en",
 	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Episodenliste",
+	"subjectOf": [
+		{
+			"@type": "Webpage",
+			"inLanguage": "de",
+			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Episodenliste"
+		}
+	],
 	"numberOfSeasons": 7,
 	"containsSeason": [
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 1,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_1",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_1"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -408,6 +422,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 2,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_2",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_2"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -935,6 +956,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 3,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_3",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_3"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -1462,6 +1490,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 4,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_4",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_4"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -1969,6 +2004,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 5,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_5",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_5"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -2496,6 +2538,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 6,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_6",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_6"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -3023,6 +3072,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 7,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_7",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Deep_Space_Nine/Staffel_7"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",

--- a/series/dsc.jsonld
+++ b/series/dsc.jsonld
@@ -14,20 +14,30 @@
 	"name": "Star Trek: Discovery",
 	"identifier": "DSC",
 	"inLanguage": "en",
-	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Discovery/Episodenliste",
+	"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Discovery",
 	"subjectOf": [
 		{
 			"@type": "Webpage",
+			"inLanguage": "en",
+			"url": "https://en.wikipedia.org/wiki/Star_Trek:_Discovery"
+		},
+		{
+			"@type": "Webpage",
 			"inLanguage": "de",
-			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Discovery/Episodenliste"
+			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Discovery"
 		}
 	],
 	"containsSeason": [
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 1,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Discovery/Staffel_1",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Discovery_(season_1)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Discovery_(season_1)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
@@ -362,8 +372,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 2,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Discovery/Staffel_2",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Discovery_(season_2)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Discovery_(season_2)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
@@ -671,8 +686,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 3,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Discovery/Staffel_3",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Discovery_(season_3)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Discovery_(season_3)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
@@ -1050,8 +1070,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 4,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Discovery/Staffel_4",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Discovery_(season_4)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Discovery_(season_4)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",

--- a/series/dsc.jsonld
+++ b/series/dsc.jsonld
@@ -15,11 +15,25 @@
 	"identifier": "DSC",
 	"inLanguage": "en",
 	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Discovery/Episodenliste",
+	"subjectOf": [
+		{
+			"@type": "Webpage",
+			"inLanguage": "de",
+			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Discovery/Episodenliste"
+		}
+	],
 	"containsSeason": [
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 1,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Discovery/Staffel_1",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Discovery/Staffel_1"
+				}
+			],
 			"numberOfEpisodes": 15,
 			"episode": [
 				{
@@ -349,6 +363,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 2,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Discovery/Staffel_2",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Discovery/Staffel_2"
+				}
+			],
 			"numberOfEpisodes": 14,
 			"episode": [
 				{
@@ -651,6 +672,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 3,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Discovery/Staffel_3",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Discovery/Staffel_3"
+				}
+			],
 			"numberOfEpisodes": 13,
 			"episode": [
 				{
@@ -1023,6 +1051,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 4,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Discovery/Staffel_4",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Discovery/Staffel_4"
+				}
+			],
 			"numberOfEpisodes": 13,
 			"episode": [
 				{

--- a/series/ent.jsonld
+++ b/series/ent.jsonld
@@ -14,12 +14,17 @@
 	"name": "Star Trek: Enterprise",
 	"identifier": "ENT",
 	"inLanguage": "en",
-	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Enterprise/Episodenliste",
+	"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Enterprise",
 	"subjectOf": [
 		{
 			"@type": "Webpage",
+			"inLanguage": "en",
+			"url": "https://en.wikipedia.org/wiki/Star_Trek:_Enterprise"
+		},
+		{
+			"@type": "Webpage",
 			"inLanguage": "de",
-			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Enterprise/Episodenliste"
+			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Enterprise"
 		}
 	],
 	"numberOfSeasons": 4,
@@ -27,8 +32,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 1,
-			"sameAs": "https://de.wikipedia.org/wiki/Enterprise/Staffel_1",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Enterprise_(season_1)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Enterprise_(season_1)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
@@ -542,8 +552,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 2,
-			"sameAs": "https://de.wikipedia.org/wiki/Enterprise/Staffel_2",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Enterprise_(season_2)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Enterprise_(season_2)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
@@ -1077,8 +1092,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 3,
-			"sameAs": "https://de.wikipedia.org/wiki/Enterprise/Staffel_3",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Enterprise_(season_3)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Enterprise_(season_3)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
@@ -1571,8 +1591,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 4,
-			"sameAs": "https://de.wikipedia.org/wiki/Enterprise/Staffel_4",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Enterprise_(season_4)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Enterprise_(season_4)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",

--- a/series/ent.jsonld
+++ b/series/ent.jsonld
@@ -15,12 +15,26 @@
 	"identifier": "ENT",
 	"inLanguage": "en",
 	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Enterprise/Episodenliste",
+	"subjectOf": [
+		{
+			"@type": "Webpage",
+			"inLanguage": "de",
+			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Enterprise/Episodenliste"
+		}
+	],
 	"numberOfSeasons": 4,
 	"containsSeason": [
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 1,
 			"sameAs": "https://de.wikipedia.org/wiki/Enterprise/Staffel_1",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Enterprise/Staffel_1"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -529,6 +543,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 2,
 			"sameAs": "https://de.wikipedia.org/wiki/Enterprise/Staffel_2",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Enterprise/Staffel_2"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -1057,6 +1078,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 3,
 			"sameAs": "https://de.wikipedia.org/wiki/Enterprise/Staffel_3",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Enterprise/Staffel_3"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -1544,6 +1572,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 4,
 			"sameAs": "https://de.wikipedia.org/wiki/Enterprise/Staffel_4",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Enterprise/Staffel_4"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",

--- a/series/index.php
+++ b/series/index.php
@@ -276,14 +276,31 @@ EOT;
       </main>
       <footer>
         Data source:
-        <a
-          <?php if ($data['sameAs']): ?>
-            property="sameAs"
-            href="<?= htmlSpecialChars($data['sameAs']) ?>"
-          <?php endif; ?>
-        >
-          Wikipedia
-        </a>
+        <?php if ($data['subjectOf']): ?>
+          <?php foreach ($data['subjectOf'] as $index => $source): ?>
+            <?php if ($index): ?>
+              &amp;
+            <? endif; ?>
+            <cite property="subjectOf" typeof="Webpage">
+              <a
+                property="url"
+                href="<?= htmlSpecialChars($source['url']) ?>"
+              >
+                Wikipedia (<?= htmlSpecialChars($source['inLanguage']) ?>)</a>
+            </cite>
+          <?php endforeach; ?>
+        <?php elseif ($data['sameAs']): ?>
+          <cite property="subjectOf" typeof="Webpage">
+            <a
+              property="url"
+              href="<?= htmlSpecialChars($data['sameAs']) ?>"
+            >
+              Wikipedia
+            </a>
+          </cite>
+        <?php else: ?>
+          <cite>Wikipedia</cite>
+        <?php endif; ?>
       </footer>
       <script>
         <?php readfile(SCRIPT); ?>

--- a/series/ld.jsonld
+++ b/series/ld.jsonld
@@ -15,11 +15,25 @@
 	"identifier": "LD",
 	"inLanguage": "en",
 	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Lower_Decks#Episodenliste",
+	"subjectOf": [
+		{
+			"@type": "Webpage",
+			"inLanguage": "de",
+			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Lower_Decks#Episodenliste"
+		}
+	],
 	"containsSeason": [
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 1,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Lower_Decks/Staffel_1",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Lower_Decks/Staffel_1"
+				}
+			],
 			"numberOfEpisodes": 10,
 			"episode": [
 				{
@@ -308,6 +322,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 2,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Lower_Decks/Staffel_2",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Lower_Decks/Staffel_2"
+				}
+			],
 			"numberOfEpisodes": 10,
 			"episode": [
 				{
@@ -602,6 +623,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 3,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Lower_Decks/Staffel_3",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Lower_Decks/Staffel_3"
+				}
+			],
 			"numberOfEpisodes": 10,
 			"episode": [
 				{

--- a/series/ld.jsonld
+++ b/series/ld.jsonld
@@ -14,20 +14,30 @@
 	"name": "Star Trek: Lower Decks",
 	"identifier": "LD",
 	"inLanguage": "en",
-	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Lower_Decks#Episodenliste",
+	"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Lower_Decks",
 	"subjectOf": [
 		{
 			"@type": "Webpage",
+			"inLanguage": "en",
+			"url": "https://en.wikipedia.org/wiki/Star_Trek:_Lower_Decks"
+		},
+		{
+			"@type": "Webpage",
 			"inLanguage": "de",
-			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Lower_Decks#Episodenliste"
+			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Lower_Decks"
 		}
 	],
 	"containsSeason": [
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 1,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Lower_Decks/Staffel_1",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Lower_Decks_(season_1)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Lower_Decks_(season_1)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
@@ -321,8 +331,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 2,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Lower_Decks/Staffel_2",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Lower_Decks_(season_2)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Lower_Decks_(season_2)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
@@ -622,8 +637,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 3,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Lower_Decks/Staffel_3",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Lower_Decks_(season_3)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Lower_Decks_(season_3)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",

--- a/series/pic.jsonld
+++ b/series/pic.jsonld
@@ -19,12 +19,12 @@
 		{
 			"@type": "Webpage",
 			"inLanguage": "en",
-			"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard#Episodes"
+			"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard"
 		},
 		{
 			"@type": "Webpage",
 			"inLanguage": "de",
-			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard#Episodenliste"
+			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard"
 		}
 	],
 	"numberOfSeasons": 3,
@@ -37,12 +37,12 @@
 				{
 					"@type": "Webpage",
 					"inLanguage": "en",
-					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_1)#Episodes"
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_1)"
 				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
-					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard/Staffel_1#Episoden"
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard/Staffel_1"
 				}
 			],
 			"numberOfEpisodes": 10,
@@ -349,12 +349,12 @@
 				{
 					"@type": "Webpage",
 					"inLanguage": "en",
-					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_2)#Episodes"
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_2)"
 				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
-					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard/Staffel_2#Episoden"
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard/Staffel_2"
 				}
 			],
 			"numberOfEpisodes": 10,
@@ -651,12 +651,12 @@
 				{
 					"@type": "Webpage",
 					"inLanguage": "en",
-					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_3)#Episodes"
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_3)"
 				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
-					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard/Staffel_3#Episoden"
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard/Staffel_3"
 				}
 			],
 			"episode": [

--- a/series/pic.jsonld
+++ b/series/pic.jsonld
@@ -37,12 +37,12 @@
 				{
 					"@type": "Webpage",
 					"inLanguage": "en",
-					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_1)"
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_1)#Episodes"
 				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
-					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard/Staffel_1"
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard/Staffel_1#Episoden"
 				}
 			],
 			"numberOfEpisodes": 10,
@@ -349,12 +349,12 @@
 				{
 					"@type": "Webpage",
 					"inLanguage": "en",
-					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_2)"
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_2)#Episodes"
 				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
-					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard/Staffel_2"
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard/Staffel_2#Episoden"
 				}
 			],
 			"numberOfEpisodes": 10,
@@ -651,12 +651,12 @@
 				{
 					"@type": "Webpage",
 					"inLanguage": "en",
-					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_3)"
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_3)#Episodes"
 				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
-					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard/Staffel_3"
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard/Staffel_3#Episoden"
 				}
 			],
 			"episode": [

--- a/series/pic.jsonld
+++ b/series/pic.jsonld
@@ -14,8 +14,13 @@
 	"name": "Star Trek: Picard",
 	"identifier": "PIC",
 	"inLanguage": "en",
-	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Picard#Episodenliste",
+	"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Picard",
 	"subjectOf": [
+		{
+			"@type": "Webpage",
+			"inLanguage": "en",
+			"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard#Episodes"
+		},
 		{
 			"@type": "Webpage",
 			"inLanguage": "de",
@@ -27,8 +32,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 1,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Picard/Staffel_1",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_1)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_1)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
@@ -334,6 +344,19 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 2,
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_2)",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_2)"
+				},
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard/Staffel_2"
+				}
+			],
 			"numberOfEpisodes": 10,
 			"episode": [
 				{
@@ -623,6 +646,19 @@
 			"@type": "TVSeason",
 			"seasonNumber": 3,
 			"numberOfEpisodes": 10,
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_3)",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Picard_(season_3)"
+				},
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard/Staffel_3"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",

--- a/series/pic.jsonld
+++ b/series/pic.jsonld
@@ -15,12 +15,26 @@
 	"identifier": "PIC",
 	"inLanguage": "en",
 	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Picard#Episodenliste",
+	"subjectOf": [
+		{
+			"@type": "Webpage",
+			"inLanguage": "de",
+			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard#Episodenliste"
+		}
+	],
 	"numberOfSeasons": 3,
 	"containsSeason": [
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 1,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Picard/Staffel_1",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Picard/Staffel_1"
+				}
+			],
 			"numberOfEpisodes": 10,
 			"episode": [
 				{

--- a/series/pro.jsonld
+++ b/series/pro.jsonld
@@ -15,12 +15,26 @@
 	"identifier": "PRO",
 	"inLanguage": "en",
 	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Prodigy#Episodenliste",
+	"subjectOf": [
+		{
+			"@type": "Webpage",
+			"inLanguage": "de",
+			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Prodigy#Episodenliste"
+		}
+	],
 	"containsSeason": [
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 1,
 			"numberOfEpisodes": 20,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Prodigy/Staffel_1",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Prodigy/Staffel_1"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",

--- a/series/pro.jsonld
+++ b/series/pro.jsonld
@@ -14,12 +14,17 @@
 	"name": "Star Trek: Prodigy",
 	"identifier": "PRO",
 	"inLanguage": "en",
-	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Prodigy#Episodenliste",
+	"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Prodigy",
 	"subjectOf": [
 		{
 			"@type": "Webpage",
+			"inLanguage": "en",
+			"url": "https://en.wikipedia.org/wiki/Star_Trek:_Prodigy"
+		},
+		{
+			"@type": "Webpage",
 			"inLanguage": "de",
-			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Prodigy#Episodenliste"
+			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Prodigy"
 		}
 	],
 	"containsSeason": [
@@ -27,7 +32,6 @@
 			"@type": "TVSeason",
 			"seasonNumber": 1,
 			"numberOfEpisodes": 20,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Prodigy/Staffel_1",
 			"subjectOf": [
 				{
 					"@type": "Webpage",

--- a/series/snw.jsonld
+++ b/series/snw.jsonld
@@ -15,6 +15,13 @@
 	"identifier": "SNW",
 	"inLanguage": "en",
 	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Strange_New_Worlds",
+	"subjectOf": [
+		{
+			"@type": "Webpage",
+			"inLanguage": "de",
+			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Strange_New_Worlds"
+		}
+	],
 	"containsSeason": [
 		{
 			"@type": "TVSeason",

--- a/series/snw.jsonld
+++ b/series/snw.jsonld
@@ -14,8 +14,13 @@
 	"name": "Star Trek: Strange New Worlds",
 	"identifier": "SNW",
 	"inLanguage": "en",
-	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Strange_New_Worlds",
+	"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Strange_New_Worlds",
 	"subjectOf": [
+		{
+			"@type": "Webpage",
+			"inLanguage": "en",
+			"url": "https://en.wikipedia.org/wiki/Star_Trek:_Strange_New_Worlds"
+		},
 		{
 			"@type": "Webpage",
 			"inLanguage": "de",
@@ -26,6 +31,19 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 1,
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Strange_New_Worlds_(season_1)",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_Strange_New_Worlds_(season_1)"
+				},
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Strange_New_Worlds/Staffel_1"
+				}
+			],
 			"numberOfEpisodes": 10,
 			"episode": [
 				{

--- a/series/st.jsonld
+++ b/series/st.jsonld
@@ -14,12 +14,17 @@
 	"name": "Star Trek: Short Treks",
 	"identifier": "ST",
 	"inLanguage": "en",
-	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Short_Treks#Episodenliste",
+	"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Short_Treks",
 	"subjectOf": [
 		{
 			"@type": "Webpage",
+			"inLanguage": "en",
+			"url": "https://en.wikipedia.org/wiki/Star_Trek:_Short_Treks"
+		},
+		{
+			"@type": "Webpage",
 			"inLanguage": "de",
-			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Short_Treks#Episodenliste"
+			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Short_Treks"
 		}
 	],
 	"numberOfSeasons": 2,

--- a/series/st.jsonld
+++ b/series/st.jsonld
@@ -15,6 +15,13 @@
 	"identifier": "ST",
 	"inLanguage": "en",
 	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Short_Treks#Episodenliste",
+	"subjectOf": [
+		{
+			"@type": "Webpage",
+			"inLanguage": "de",
+			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Short_Treks#Episodenliste"
+		}
+	],
 	"numberOfSeasons": 2,
 	"containsSeason": [
 		{

--- a/series/tas.jsonld
+++ b/series/tas.jsonld
@@ -14,12 +14,17 @@
 	"name": "Star Trek: The Animated Series",
 	"identifier": "TAS",
 	"inLanguage": "en",
-	"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_The_Animated_Series#Episodes",
+	"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_The_Animated_Series",
 	"subjectOf": [
 		{
 			"@type": "Webpage",
+			"inLanguage": "en",
+			"url": "https://en.wikipedia.org/wiki/Star_Trek:_The_Animated_Series"
+		},
+		{
+			"@type": "Webpage",
 			"inLanguage": "de",
-			"url": "https://en.wikipedia.org/wiki/Star_Trek:_The_Animated_Series#Episodes"
+			"url": "https://de.wikipedia.org/wiki/Die_Enterprise"
 		}
 	],
 	"numberOfSeasons": 2,

--- a/series/tas.jsonld
+++ b/series/tas.jsonld
@@ -15,6 +15,13 @@
 	"identifier": "TAS",
 	"inLanguage": "en",
 	"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_The_Animated_Series#Episodes",
+	"subjectOf": [
+		{
+			"@type": "Webpage",
+			"inLanguage": "de",
+			"url": "https://en.wikipedia.org/wiki/Star_Trek:_The_Animated_Series#Episodes"
+		}
+	],
 	"numberOfSeasons": 2,
 	"containsSeason": [
 		{

--- a/series/tng.jsonld
+++ b/series/tng.jsonld
@@ -15,12 +15,26 @@
 	"identifier": "TNG",
 	"inLanguage": "en",
 	"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Episodenliste",
+	"subjectOf": [
+		{
+			"@type": "Webpage",
+			"inLanguage": "de",
+			"url": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Episodenliste"
+		}
+	],
 	"numberOfSeasons": 7,
 	"containsSeason": [
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 1,
 			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_1",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_1"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -548,6 +562,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 2,
 			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_2",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_2"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -997,6 +1018,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 3,
 			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_3",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_3"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -1526,6 +1554,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 4,
 			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_4",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_4"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -2054,6 +2089,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 5,
 			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_5",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_5"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -2584,6 +2626,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 6,
 			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_6",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_6"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -3111,6 +3160,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 7,
 			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_7",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_7"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",

--- a/series/tng.jsonld
+++ b/series/tng.jsonld
@@ -14,12 +14,17 @@
 	"name": "Star Trek: The Next Generation",
 	"identifier": "TNG",
 	"inLanguage": "en",
-	"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Episodenliste",
+	"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_The_Next_Generation",
 	"subjectOf": [
 		{
 			"@type": "Webpage",
+			"inLanguage": "en",
+			"url": "https://en.wikipedia.org/wiki/Star_Trek:_The_Next_Generation"
+		},
+		{
+			"@type": "Webpage",
 			"inLanguage": "de",
-			"url": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Episodenliste"
+			"url": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert"
 		}
 	],
 	"numberOfSeasons": 7,
@@ -27,8 +32,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 1,
-			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_1",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_The_Next_Generation_(season_1)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_The_Next_Generation_(season_1)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
@@ -561,8 +571,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 2,
-			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_2",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_The_Next_Generation_(season_2)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_The_Next_Generation_(season_2)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
@@ -1017,8 +1032,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 3,
-			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_3",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_The_Next_Generation_(season_3)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_The_Next_Generation_(season_3)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
@@ -1553,8 +1573,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 4,
-			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_4",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_The_Next_Generation_(season_4)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_The_Next_Generation_(season_4)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
@@ -2088,8 +2113,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 5,
-			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_5",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_The_Next_Generation_(season_5)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_The_Next_Generation_(season_5)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
@@ -2625,8 +2655,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 6,
-			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_6",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_The_Next_Generation_(season_6)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_The_Next_Generation_(season_6)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
@@ -3159,8 +3194,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 7,
-			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise_%E2%80%93_Das_n%C3%A4chste_Jahrhundert/Staffel_7",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_The_Next_Generation_(season_7)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_The_Next_Generation_(season_7)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",

--- a/series/tos.jsonld
+++ b/series/tos.jsonld
@@ -14,12 +14,17 @@
 	"name": "Star Trek: The Original Series",
 	"identifier": "TOS",
 	"inLanguage": "en",
-	"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise/Episodenliste",
+	"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_The_Original_Series",
 	"subjectOf": [
 		{
 			"@type": "Webpage",
+			"inLanguage": "en",
+			"url": "https://en.wikipedia.org/wiki/Star_Trek:_The_Original_Series"
+		},
+		{
+			"@type": "Webpage",
 			"inLanguage": "de",
-			"url": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise/Episodenliste"
+			"url": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise"
 		}
 	],
 	"numberOfSeasons": 3,
@@ -50,8 +55,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 1,
-			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise/Staffel_1",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_The_Original_Series_(season_1)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_The_Original_Series_(season_1)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
@@ -648,8 +658,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 2,
-			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise/Staffel_2",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_The_Original_Series_(season_2)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_The_Original_Series_(season_2)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",
@@ -1184,8 +1199,13 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 3,
-			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise/Staffel_3",
+			"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_The_Original_Series_(season_3)",
 			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "en",
+					"url": "https://en.wikipedia.org/wiki/Star_Trek:_The_Original_Series_(season_3)"
+				},
 				{
 					"@type": "Webpage",
 					"inLanguage": "de",

--- a/series/tos.jsonld
+++ b/series/tos.jsonld
@@ -15,6 +15,13 @@
 	"identifier": "TOS",
 	"inLanguage": "en",
 	"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise/Episodenliste",
+	"subjectOf": [
+		{
+			"@type": "Webpage",
+			"inLanguage": "de",
+			"url": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise/Episodenliste"
+		}
+	],
 	"numberOfSeasons": 3,
 	"containsSeason": [
 		{
@@ -44,6 +51,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 1,
 			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise/Staffel_1",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise/Staffel_1"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -635,6 +649,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 2,
 			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise/Staffel_2",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise/Staffel_2"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -1164,6 +1185,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 3,
 			"sameAs": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise/Staffel_3",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Raumschiff_Enterprise/Staffel_3"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",

--- a/series/voy.jsonld
+++ b/series/voy.jsonld
@@ -14,12 +14,17 @@
 	"name": "Star Trek: Voyager",
 	"identifier": "VOY",
 	"inLanguage": "en",
-	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Episodenliste",
+	"sameAs": "https://en.wikipedia.org/wiki/Star_Trek:_Voyager",
 	"subjectOf": [
 		{
 			"@type": "Webpage",
+			"inLanguage": "en",
+			"url": "https://en.wikipedia.org/wiki/Star_Trek:_Voyager"
+		},
+		{
+			"@type": "Webpage",
 			"inLanguage": "de",
-			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Episodenliste"
+			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager"
 		}
 	],
 	"numberOfSeasons": 7,
@@ -27,7 +32,6 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 1,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_1",
 			"subjectOf": [
 				{
 					"@type": "Webpage",
@@ -386,7 +390,6 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 2,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_2",
 			"subjectOf": [
 				{
 					"@type": "Webpage",
@@ -983,7 +986,6 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 3,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_3",
 			"subjectOf": [
 				{
 					"@type": "Webpage",
@@ -1586,7 +1588,6 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 4,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_4",
 			"subjectOf": [
 				{
 					"@type": "Webpage",
@@ -2198,7 +2199,6 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 5,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_5",
 			"subjectOf": [
 				{
 					"@type": "Webpage",
@@ -2747,7 +2747,6 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 6,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_6",
 			"subjectOf": [
 				{
 					"@type": "Webpage",
@@ -3359,7 +3358,6 @@
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 7,
-			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_7",
 			"subjectOf": [
 				{
 					"@type": "Webpage",

--- a/series/voy.jsonld
+++ b/series/voy.jsonld
@@ -15,12 +15,26 @@
 	"identifier": "VOY",
 	"inLanguage": "en",
 	"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Episodenliste",
+	"subjectOf": [
+		{
+			"@type": "Webpage",
+			"inLanguage": "de",
+			"url": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Episodenliste"
+		}
+	],
 	"numberOfSeasons": 7,
 	"containsSeason": [
 		{
 			"@type": "TVSeason",
 			"seasonNumber": 1,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_1",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_1"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -373,6 +387,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 2,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_2",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_2"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -963,6 +984,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 3,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_3",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_3"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -1559,6 +1587,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 4,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_4",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_4"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -2164,6 +2199,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 5,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_5",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_5"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -2706,6 +2748,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 6,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_6",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_6"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",
@@ -3311,6 +3360,13 @@
 			"@type": "TVSeason",
 			"seasonNumber": 7,
 			"sameAs": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_7",
+			"subjectOf": [
+				{
+					"@type": "Webpage",
+					"inLanguage": "de",
+					"url": "https://de.wikipedia.org/wiki/Star_Trek:_Raumschiff_Voyager/Staffel_7"
+				}
+			],
 			"episode": [
 				{
 					"@type": "TVEpisode",

--- a/style.css
+++ b/style.css
@@ -126,6 +126,10 @@ footer {
 	border-color: transparent;
 }
 
+footer cite {
+	font-style: normal;
+}
+
 nav ol {
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
replaces #19

- `sameAs` points to English Wikipedia
- links to German and English Wikipedia as `subjectOf`

